### PR TITLE
Add `ToPoint` type class.

### DIFF
--- a/src/main/scala/io/razem/influxdbclient/Database.scala
+++ b/src/main/scala/io/razem/influxdbclient/Database.scala
@@ -4,7 +4,6 @@ import io.razem.influxdbclient.Parameter.Consistency.Consistency
 import io.razem.influxdbclient.Parameter.Precision.Precision
 import io.razem.influxdbclient.implicits.anyToPoint
 
-import scala.annotation.implicitNotFound
 import scala.concurrent.{ExecutionContext, Future}
 
 class Database protected[influxdbclient]

--- a/src/main/scala/io/razem/influxdbclient/Database.scala
+++ b/src/main/scala/io/razem/influxdbclient/Database.scala
@@ -2,7 +2,9 @@ package io.razem.influxdbclient
 
 import io.razem.influxdbclient.Parameter.Consistency.Consistency
 import io.razem.influxdbclient.Parameter.Precision.Precision
+import io.razem.influxdbclient.implicits.anyToPoint
 
+import scala.annotation.implicitNotFound
 import scala.concurrent.{ExecutionContext, Future}
 
 class Database protected[influxdbclient]
@@ -12,12 +14,16 @@ class Database protected[influxdbclient]
   with RetentionPolicyManagement
   with DatabaseManagement
 {
-  def write(point: Point,
+
+  @implicitNotFound(
+    "Cannot find implicit ToPoint instance for type ${A}. Ensure that instance is implemented and reachable."
+  )
+  def write[A](metric: A,
             precision: Precision = null,
             consistency: Consistency = null,
-            retentionPolicy: String = null): Future[Boolean] =
+            retentionPolicy: String = null)(implicit toPoint: ToPoint[A]): Future[Boolean] =
   {
-    executeWrite(point.serialize(), precision, consistency, retentionPolicy)
+    executeWrite(metric.serialize(), precision, consistency, retentionPolicy)
   }
 
   def bulkWrite(points: Seq[Point],

--- a/src/main/scala/io/razem/influxdbclient/Database.scala
+++ b/src/main/scala/io/razem/influxdbclient/Database.scala
@@ -15,9 +15,6 @@ class Database protected[influxdbclient]
   with DatabaseManagement
 {
 
-  @implicitNotFound(
-    "Cannot find implicit ToPoint instance for type ${A}. Ensure that instance is implemented and reachable."
-  )
   def write[A](metric: A,
             precision: Precision = null,
             consistency: Consistency = null,

--- a/src/main/scala/io/razem/influxdbclient/ToPoint.scala
+++ b/src/main/scala/io/razem/influxdbclient/ToPoint.scala
@@ -1,0 +1,16 @@
+package io.razem.influxdbclient
+
+trait ToPoint[A] {
+
+  def convert(value: A): Point
+
+}
+
+object ToPoint {
+
+  implicit object PointToPoint extends ToPoint[Point]{
+    @inline
+    override def convert(value: Point): Point = value
+  }
+
+}

--- a/src/main/scala/io/razem/influxdbclient/ToPoint.scala
+++ b/src/main/scala/io/razem/influxdbclient/ToPoint.scala
@@ -1,5 +1,10 @@
 package io.razem.influxdbclient
 
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(
+  "Cannot find implicit ToPoint instance for type ${A}. Ensure that instance is implemented and reachable."
+)
 trait ToPoint[A] {
 
   def convert(value: A): Point

--- a/src/main/scala/io/razem/influxdbclient/implicits/package.scala
+++ b/src/main/scala/io/razem/influxdbclient/implicits/package.scala
@@ -1,7 +1,5 @@
 package io.razem.influxdbclient
 
-import scala.annotation.implicitNotFound
-
 package object implicits {
 
   implicit class ToPointSyntax[A](val value: A) extends AnyVal {
@@ -23,9 +21,6 @@ package object implicits {
      *   }
      * }}}
      */
-    @implicitNotFound(
-      "Cannot find implicit ToPoint instance for type ${A}. Ensure that instance is implemented and reachable."
-    )
     def toPoint(implicit toPoint: ToPoint[A]): Point = toPoint.convert(value)
 
   }
@@ -50,9 +45,6 @@ package object implicits {
    *   }
    * }}}
    */
-  @implicitNotFound(
-    "Cannot find implicit ToPoint instance for type ${A}. Ensure that instance is implemented and reachable."
-  )
   implicit def anyToPoint[A](value: A)(implicit toPoint: ToPoint[A]): Point =
     toPoint.convert(value)
 

--- a/src/main/scala/io/razem/influxdbclient/implicits/package.scala
+++ b/src/main/scala/io/razem/influxdbclient/implicits/package.scala
@@ -1,0 +1,59 @@
+package io.razem.influxdbclient
+
+import scala.annotation.implicitNotFound
+
+package object implicits {
+
+  implicit class ToPointSyntax[A](val value: A) extends AnyVal {
+
+    /**
+     * Example:
+     * {{{
+     *   import io.razem.influxdbclient.ToPoint
+     *
+     *   case class UserLoggedIn(userId: Long)
+     *   object UserLoggedIn {
+     *     implicit val userLoggedInToPoint: ToPoint[UserLoggedIn] = u =>
+     *       Point("user_logins").addTag("user_id", u.userId)
+     *   }
+     *   // Usage:
+     *   def loginUser(user: User) = {
+     *     influx.write(UserLoggedIn(user.id).toPoint)
+     *     // ...
+     *   }
+     * }}}
+     */
+    @implicitNotFound(
+      "Cannot find implicit ToPoint instance for type ${A}. Ensure that instance is implemented and reachable."
+    )
+    def toPoint(implicit toPoint: ToPoint[A]): Point = toPoint.convert(value)
+
+  }
+
+  /**
+   * Implicitly converts any type `A` to `Point` if it
+   * has `ToPoint[A]` type class implementation in scope.
+   *
+   * Example:
+   * {{{
+   *   import io.razem.influxdbclient.ToPoint
+   *
+   *   case class UserLoggedIn(userId: Long)
+   *   object UserLoggedIn {
+   *     implicit val userLoggedInToPoint: ToPoint[UserLoggedIn] = u =>
+   *       Point("user_logins").addTag("user_id", u.userId)
+   *   }
+   *   // Usage:
+   *   def loginUser(user: User) = {
+   *     influx.write(UserLoggedIn(user.id))
+   *     // ...
+   *   }
+   * }}}
+   */
+  @implicitNotFound(
+    "Cannot find implicit ToPoint instance for type ${A}. Ensure that instance is implemented and reachable."
+  )
+  implicit def anyToPoint[A](value: A)(implicit toPoint: ToPoint[A]): Point =
+    toPoint.convert(value)
+
+}

--- a/src/test/scala/io/razem/influxdbclient/DatabaseSuite.scala
+++ b/src/test/scala/io/razem/influxdbclient/DatabaseSuite.scala
@@ -1,8 +1,9 @@
 package io.razem.influxdbclient
 
-import io.razem.influxdbclient.Mocks.{ExceptionThrowingHttpClient, ErrorReturningHttpClient}
+import io.razem.influxdbclient.Mocks.{ErrorReturningHttpClient, ExceptionThrowingHttpClient}
 import io.razem.influxdbclient.Parameter.{Consistency, Precision}
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfter}
+import io.razem.influxdbclient.implicits._
+import org.scalatest.BeforeAndAfter
 
 class DatabaseSuite extends CustomTestSuite with BeforeAndAfter {
 
@@ -138,6 +139,24 @@ class DatabaseSuite extends CustomTestSuite with BeforeAndAfter {
     } catch {
       case e: ServerUnavailableException => // expected
     }
+  }
+
+  test("A point can be written using ToPoint type class") {
+    await(database.write(Metric(123, "tag_value")))
+    val result = await(database.query("SELECT * FROM test_measurement WHERE tag_key='tag_value'"))
+    assert(result.series.length == 1)
+  }
+
+  test("A point can be written using ToPoint syntax") {
+    await(database.write(Metric(123, "tag_value").toPoint))
+    val result = await(database.query("SELECT * FROM test_measurement WHERE tag_key='tag_value'"))
+    assert(result.series.length == 1)
+  }
+
+  test("A point can be written using implicit conversion") {
+    await(database.write(Metric(123, "tag_value")))
+    val result = await(database.query("SELECT * FROM test_measurement WHERE tag_key='tag_value'"))
+    assert(result.series.length == 1)
   }
 
 }

--- a/src/test/scala/io/razem/influxdbclient/Metric.scala
+++ b/src/test/scala/io/razem/influxdbclient/Metric.scala
@@ -1,0 +1,14 @@
+package io.razem.influxdbclient
+
+/**
+ * Class used for testing purposes.
+ */
+case class Metric(value: Int, tag: String)
+
+object Metric {
+  implicit val metricToPoint: ToPoint[Metric] = m =>
+    Point("test_measurement")
+      .addField("value", m.value)
+      .addTag("tag_key", m.tag)
+
+} 


### PR DESCRIPTION
Main reason of adding this feature is to allow submitting
custom domain models to InfluxDB without constructing Point instance
every time.